### PR TITLE
OCX-402 Fix access control errors for CDM when DDF-UI is installed

### DIFF
--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -258,37 +258,57 @@
                 <version>1.5.3</version>
                 <executions>
                     <execution>
+                        <id>replace-system-properties</id>
                         <phase>generate-resources</phase>
                         <goals>
                             <goal>replace</goal>
                         </goals>
+                        <configuration>
+                            <file>
+                                ${project.basedir}/target/dependencies/ddf-kernel-${ddf.version}/etc/custom.system.properties
+                            </file>
+                            <regex>true</regex>
+                            <replacements>
+                                <replacement>
+                                    <token>org.codice.ddf.system.branding=.*</token>
+                                    <value>org.codice.ddf.system.branding=${branding-lowercase}</value>
+                                </replacement>
+                                <replacement>
+                                    <token>org.codice.ddf.system.siteName=.*</token>
+                                    <value>org.codice.ddf.system.siteName=${sitename.default}</value>
+                                </replacement>
+                                <replacement>
+                                    <token>org.codice.ddf.system.version=.*</token>
+                                    <value>org.codice.ddf.system.version=${project.version}</value>
+                                </replacement>
+                                <replacement>
+                                    <token>org.codice.ddf.system.organization=.*</token>
+                                    <value>org.codice.ddf.system.organization=${project.organization.name}
+                                    </value>
+                                </replacement>
+                            </replacements>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>replace-security-policy</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>
+                                ${project.basedir}/target/dependencies/ddf-kernel-${ddf.version}/security/configurations.policy
+                            </file>
+                            <regex>true</regex>
+                            <replacements>
+                                <replacement>
+                                    <token>grant codeBase "file:/catalog-core-directorymonitor.*</token>
+                                    <value>grant codeBase "file:/catalog-core-directorymonitor/org.apache.camel.camel-core/org.apache.camel.camel-blueprint/catalog-core-camelcomponent/catalog-core-urlresourcereader/com.google.guava/catalog-core-standardframework/org.apache.tika.core/platform-util" {</value>
+                                </replacement>
+                            </replacements>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <file>
-                        ${project.basedir}/target/dependencies/ddf-kernel-${ddf.version}/etc/custom.system.properties
-                    </file>
-                    <regex>true</regex>
-                    <replacements>
-                        <replacement>
-                            <token>org.codice.ddf.system.branding=.*</token>
-                            <value>org.codice.ddf.system.branding=${branding-lowercase}</value>
-                        </replacement>
-                        <replacement>
-                            <token>org.codice.ddf.system.siteName=.*</token>
-                            <value>org.codice.ddf.system.siteName=${sitename.default}</value>
-                        </replacement>
-                        <replacement>
-                            <token>org.codice.ddf.system.version=.*</token>
-                            <value>org.codice.ddf.system.version=${project.version}</value>
-                        </replacement>
-                        <replacement>
-                            <token>org.codice.ddf.system.organization=.*</token>
-                            <value>org.codice.ddf.system.organization=${project.organization.name}
-                            </value>
-                        </replacement>
-                    </replacements>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>

--- a/distribution/common/src/main/resources/security/ui.policy
+++ b/distribution/common/src/main/resources/security/ui.policy
@@ -1,0 +1,5 @@
+priority "grant";
+
+grant codeBase "file:/org.apache.felix.fileinstall" {
+  permission java.io.FilePermission "${ddf.home.perm}wrap:mvn:org.checkerframework${/}-", "read";
+}


### PR DESCRIPTION
#### What does this PR do?
1. Adds `platform-util` to the CDM section of DDF's `configurations.policy`.
2. Adds a new `ui.policy` file that adds a file permission for checkerframework to the felix fileinstall bundle.

#### Who is reviewing it?
@clockard
@aj-brooks 
@kcover 

#### How should this be tested?
Ask @clockard for more details but you should be able to set up a content directory monitor with the DDF-UI 4.0.0 bundles installed and it should work correctly.

In the Alliance distribution that gets built, you should be able to verify in the `security` folder that the `configurations.policy` file was correctly changed and that there is a new `ui.policy` file.

#### What are the relevant tickets?
[OCX-402](https://octoconsulting.atlassian.net/browse/OCX-402)